### PR TITLE
Config faraday adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ rvm:
   - 2.3.3
   - 2.2.6
 services:
-  - elasticsearch
+  - elasticsearch-1.7.6
 before_install: gem install bundler -v 1.12.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ rvm:
   - 2.3.3
   - 2.2.6
 services:
-  - elasticsearch-1.7.6
+  - elasticsearch
 before_install: gem install bundler -v 1.12.5

--- a/lib/elastic/configuration.rb
+++ b/lib/elastic/configuration.rb
@@ -61,7 +61,11 @@ module Elastic
     private
 
     def default_api_client
-      @default_api_client ||= Elasticsearch::Client.new host: @host, port: @port
+      @default_api_client ||= Elasticsearch::Client.new(
+        host: @host,
+        port: @port,
+        adapter: @adapter
+      )
     end
 
     def default_logger

--- a/lib/elastic/configuration.rb
+++ b/lib/elastic/configuration.rb
@@ -14,8 +14,19 @@ module Elastic
       disable_index_name_caching: false
     }
 
-    attr_accessor :host, :port, :api_client, :index, :page_size, :coord_similarity, :logger,
-      :import_batch_size, :whiny_indices, :time_zone, :disable_indexing, :disable_index_name_caching
+    attr_accessor :host,
+                  :port,
+                  :adapter,
+                  :api_client,
+                  :index,
+                  :page_size,
+                  :coord_similarity,
+                  :logger,
+                  :import_batch_size,
+                  :whiny_indices,
+                  :time_zone,
+                  :disable_indexing,
+                  :disable_index_name_caching
 
     def initialize
       assign_attributes DEFAULTS

--- a/lib/generators/elastic/templates/elastic.yml
+++ b/lib/generators/elastic/templates/elastic.yml
@@ -3,6 +3,8 @@ development:
   port: 9200
   index: '<%= Rails.application.class.parent_name.to_s.underscore %>_develop'
   whiny_indices: true
+  # Config Faraday's adapter
+  # adapter: :patron
 
 test:
   host: '127.0.0.1'

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -50,6 +50,11 @@ describe Elastic::Configuration do
       expect(config.host).to eq('192.168.1.23')
       expect(config.port).to eq(9201)
     end
+
+    it 'adapter' do
+      config.adapter = :patron
+      expect(config.adapter).to eq(:patron)
+    end
   end
 
   # Helpers

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -27,24 +27,24 @@ describe Elastic::Configuration do
   end
 
   context 'when assign custom attributes' do
-    it 'custom api_client' do
+    it 'api_client' do
       config.api_client = custom_api_client
       expect(config.api_client).to be(custom_api_client)
     end
 
-    it 'custom logger' do
+    it 'logger' do
       config.logger = custom_logger
       expect(config.logger).to be(custom_logger)
     end
 
-    it 'custom time_zone' do
+    it 'time_zone' do
       config.time_zone = custom_time_zone
       expect(config.time_zone).to be(custom_time_zone)
     end
 
     # Just test assignations because this parameters are
-    # sended to Elasticsearch::Client.new
-    it 'custom host and port' do
+    # sended to Elasticsearch::Transport::Client
+    it 'host and port' do
       config.host = '192.168.1.23'
       config.port = 9201
       expect(config.host).to eq('192.168.1.23')

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe Elastic::Configuration do
+  let(:custom_logger) { Logger.new(STDOUT) }
+  let(:custom_api_client) { define_custom_api_client }
+  let(:custom_time_zone) { define_custom_time_zone }
+  let(:config) { described_class.new }
+
+  context 'when initialize without arguments' do
+    describe 'has default attributes' do
+      it { expect(config.host).to eq '127.0.0.1' }
+      it { expect(config.port).to be 9200 }
+      it { expect(config.page_size).to be(20) }
+      it { expect(config.coord_similarity).to be true }
+      it { expect(config.import_batch_size).to be 10_000 }
+      it { expect(config.whiny_indices).to be false }
+      it { expect(config.disable_indexing).to be false }
+      it { expect(config.disable_index_name_caching).to be false }
+      it { expect(config.logger).to be_a(Logger) }
+      it { expect(config.time_zone).to be_a(ActiveSupport::TimeZone) }
+      it {
+        expect(config.api_client).to be_a(
+          Elasticsearch::Transport::Client
+        )
+      }
+    end
+  end
+
+  context 'when assign custom attributes' do
+    it 'custom api_client' do
+      config.api_client = custom_api_client
+      expect(config.api_client).to be(custom_api_client)
+    end
+
+    it 'custom logger' do
+      config.logger = custom_logger
+      expect(config.logger).to be(custom_logger)
+    end
+
+    it 'custom time_zone' do
+      config.time_zone = custom_time_zone
+      expect(config.time_zone).to be(custom_time_zone)
+    end
+
+    # Just test assignations because this parameters are
+    # sended to Elasticsearch::Client.new
+    it 'custom host and port' do
+      config.host = '192.168.1.23'
+      config.port = 9201
+      expect(config.host).to eq('192.168.1.23')
+      expect(config.port).to eq(9201)
+    end
+  end
+
+  # Helpers
+  def define_custom_api_client
+    Elasticsearch::Client.new host: '192.168.30.3', port: 9205
+  end
+
+  def define_custom_logger
+    Logger.new(STDOUT)
+  end
+
+  def define_custom_time_zone
+    ActiveSupport::TimeZone.new('Santiago')
+  end
+end


### PR DESCRIPTION
I've implemented this to solve [#5](https://github.com/platanus/elastic-rails/issues/5)

Basically this follow the suggestion to add the `adapter` option to `Elastic::Configuration`.

I think in the future we can discuss how to configure directly on `elastic.yml` all parameters allowed in https://github.com/elastic/elasticsearch-ruby/blob/master/elasticsearch-transport/lib/elasticsearch/transport/client.rb under the scope `client` or something and send it automatically. Maybe something like this:

```yml
development:
  client:
    host: '127.0.0.1'
    port: 9200
    adapter: :httpclient
    serializer_class: Serializer
    send_get_body_as: 'asdf'
```

And then parse and send it to `Configure`. I think this could be on https://github.com/platanus/elastic-rails/blob/master/lib/elastic/configuration.rb#L28