### PR TITLE
Add elasticsearch 5.x support

### DIFF
--- a/elastic.gemspec
+++ b/elastic.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "elasticsearch", "~> 1.0", ">= 1.0.18"
+  spec.add_dependency "elasticsearch", "~> 5.0.4"
   spec.add_dependency "activesupport"
 
   spec.add_development_dependency "bundler", "~> 1.6"

--- a/lib/elastic/core/query_assembler.rb
+++ b/lib/elastic/core/query_assembler.rb
@@ -11,7 +11,7 @@ module Elastic::Core
 
     def assemble_total
       query = build_base_query
-      query.size = 0
+      query.size = 10000
 
       if grouped?
         attach_groups(query)
@@ -36,7 +36,7 @@ module Elastic::Core
 
     def assemble_metrics(_aggs)
       query = build_base_query
-      query.size = 0
+      query.size = 10000
 
       last = attach_groups(query)
       last.aggregations = _aggs
@@ -59,7 +59,7 @@ module Elastic::Core
         query.offset = @config.offset
         query = sort_node(query)
       else
-        query.size = 0
+        query.size = 10000
         last = attach_groups query
         last.aggregate sort_node Elastic::Nodes::TopHits.build('default')
 

--- a/lib/elastic/datatypes/default.rb
+++ b/lib/elastic/datatypes/default.rb
@@ -52,7 +52,7 @@ module Elastic::Datatypes
     end
 
     def terms_aggregation_defaults
-      { size: 0 }
+      { size: 10000 }
     end
 
     def date_histogram_aggregation_defaults

--- a/lib/elastic/datatypes/term.rb
+++ b/lib/elastic/datatypes/term.rb
@@ -2,8 +2,7 @@ module Elastic::Datatypes
   class Term < Default
     def mapping_options
       options = super
-      options[:type] = 'string'
-      options[:index] = 'not_analyzed'
+      options[:type] = 'keyword'
       options
     end
   end

--- a/lib/elastic/railties/ar_helpers.rb
+++ b/lib/elastic/railties/ar_helpers.rb
@@ -38,8 +38,8 @@ module Elastic::Railties
     # rubocop:disable Metrics/CyclomaticComplexity
     def ar_type_to_options(_type)
       case _type.try(:to_sym)
-      when :text              then { type: :string }
-      when :string            then { type: :string, index: 'not_analyzed' }
+      when :text              then { type: :text }
+      when :string            then { type: :keyword }
       when :integer           then { type: :long } # not sure..
       when :float, :decimal   then { type: :double } # not sure..
       when :date              then { type: :date }

--- a/spec/lib/commands/build_agg_from_params_spec.rb
+++ b/spec/lib/commands/build_agg_from_params_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 describe Elastic::Commands::BuildAggFromParams do
   let!(:foo_index) do
     build_index('FooIndex', migrate: true) do
-      field :foo, type: :string
+      field :foo, type: :text
       field :bar, type: :date
 
       nested :nested do
-        field :field, type: :string
+        field :field, type: :text
       end
     end
   end

--- a/spec/lib/commands/compare_mappings_spec.rb
+++ b/spec/lib/commands/compare_mappings_spec.rb
@@ -8,7 +8,7 @@ describe Elastic::Commands::CompareMappings do
   it "returns the properties that are in user but not in current" do
     user = {
       'properties' => {
-        'foo' => { 'type' => 'string', 'index' => 'not_analyzed' },
+        'foo' => { 'type' => 'keyword' },
         'qux' => { 'type' => 'integer' },
         'baz' => { 'type' => 'integer' }
       }
@@ -16,8 +16,8 @@ describe Elastic::Commands::CompareMappings do
 
     current = {
       'properties' => {
-        'foo' => { 'type' => 'string', 'index' => 'not_analyzed' },
-        'bar' => { 'type' => 'string', 'index' => 'not_analyzed' }
+        'foo' => { 'type' => 'keyword' },
+        'bar' => { 'type' => 'keyword' }
       }
     }
 
@@ -27,8 +27,8 @@ describe Elastic::Commands::CompareMappings do
   it "returns user properties that are different from current properties" do
     user = {
       'properties' => {
-        'foo' => { 'type' => 'string', 'index' => 'not_analyzed' },
-        'bar' => { 'type' => 'integer' }
+        'foo' => { 'type' => 'string' },
+        'bar' => { 'type' => 'string' }
       }
     }
 
@@ -39,7 +39,7 @@ describe Elastic::Commands::CompareMappings do
       }
     }
 
-    expect(perform(current: current, user: user)).to eq(['foo'])
+    expect(perform(current: current, user: user)).to eq(['bar'])
   end
 
   it "properly handles nested properties" do

--- a/spec/lib/core/connector_spec.rb
+++ b/spec/lib/core/connector_spec.rb
@@ -6,7 +6,7 @@ describe Elastic::Core::Connector do
   let(:mapping) do
     {
       'properties' => {
-        'foo' => { 'type' => 'string', 'index' => 'not_analyzed' },
+        'foo' => { 'type' => 'keyword' },
         'bar' => { 'type' => 'integer' }
       }
     }
@@ -31,7 +31,6 @@ describe Elastic::Core::Connector do
       it "creates the new index with the provided mapping" do
         expect { connector.remap }
           .to change { api.indices.exists? index: index_name }.to true
-
         expect(es_index_mappings(index_name, 'type_a')).to eq mapping
         expect(es_index_mappings(index_name, 'type_b')).to eq mapping
       end
@@ -229,13 +228,11 @@ describe Elastic::Core::Connector do
 
         connector.rollover do
           connector.index('_id' => 'bar', '_type' => 'type_a', 'data' => { foo: 'inside' })
-
           Thread.new do
             connector.delete('_id' => 'foo', '_type' => 'type_a')
             connector.delete('_id' => 'bar', '_type' => 'type_a')
           end.join
         end
-
         expect(es_index_count(index_name)).to be 0
       end
     end

--- a/spec/lib/datatypes/term_spec.rb
+++ b/spec/lib/datatypes/term_spec.rb
@@ -7,7 +7,7 @@ describe Elastic::Datatypes::Term do
 
   describe "mapping_options" do
     it "sets special term options" do
-      expect(datatype.mapping_options).to eq(type: 'string', index: 'not_analyzed')
+      expect(datatype.mapping_options).to eq(type: 'keyword')
     end
   end
 

--- a/spec/lib/datatypes/time_spec.rb
+++ b/spec/lib/datatypes/time_spec.rb
@@ -26,7 +26,7 @@ describe Elastic::Datatypes::Time do
     it "returns time in configured timezone" do
       expect(datatype.prepare_value_for_result(es_date_str).zone).to eq 'UTC'
       Elastic.config.time_zone = 'Santiago'
-      expect(datatype.prepare_value_for_result(es_date_str).zone).to eq 'CLT'
+      expect(datatype.prepare_value_for_result(es_date_str).zone).to eq '-04'
     end
   end
 

--- a/spec/lib/railties/ar_helpers_spec.rb
+++ b/spec/lib/railties/ar_helpers_spec.rb
@@ -13,7 +13,7 @@ describe Elastic::Railties::ARHelpers do
       Class.new do
         def self.columns_hash
           {
-            'foo' => OpenStruct.new(type: 'text'),
+            'foo' => OpenStruct.new(type: 'string'),
             'bar' => OpenStruct.new(type: 'date'),
             'baz' => OpenStruct.new(type: 'date')
           }
@@ -31,7 +31,7 @@ describe Elastic::Railties::ARHelpers do
     end
 
     it "infers type from column type" do
-      expect(helpers.infer_ar4_field_options(target, 'foo')).to eq(type: :string)
+      expect(helpers.infer_ar4_field_options(target, 'foo')).to eq(type: :keyword)
     end
 
     it "returns nil if target is occluded by a serializer" do
@@ -48,7 +48,7 @@ describe Elastic::Railties::ARHelpers do
       Class.new do
         def self.type_for_attribute(_name)
           {
-            'foo' => OpenStruct.new(type: 'text'),
+            'foo' => OpenStruct.new(type: 'string'),
             'bar' => OpenStruct.new(to_s: 'ActiveRecord::Type::Serialized'),
             'baz' => OpenStruct.new(type: 'date')
           }.fetch(_name, nil)
@@ -60,7 +60,7 @@ describe Elastic::Railties::ARHelpers do
     end
 
     it "infers type from column type" do
-      expect(helpers.infer_ar5_field_options(target, 'foo')).to eq(type: :string)
+      expect(helpers.infer_ar5_field_options(target, 'foo')).to eq(type: :keyword)
     end
 
     it "returns nil if target is occluded by a serializer" do

--- a/spec/lib/type_spec.rb
+++ b/spec/lib/type_spec.rb
@@ -6,7 +6,7 @@ describe Elastic::Type do
 
   let(:root_index) do
     build_index('RootIndex', target: root_type) do
-      field :foo, type: :string
+      field :foo, type: :text
       field :bar, type: :long, transform: -> { self + 1 }
 
       nested :tags do
@@ -32,12 +32,12 @@ describe Elastic::Type do
     it "holds the proper mapping structure" do
       expect(root_index.definition.as_es_mapping).to eq(
         'properties' => {
-          'foo' => { 'type' => 'string' },
+          'foo' => { 'type' => 'text' },
           'bar' => { 'type' => 'long' },
           'tags' => {
             'type' => 'nested',
             'properties' => {
-              'name' => { 'type' => 'string', 'index' => 'not_analyzed' }
+              'name' => { 'type' => 'keyword' }
             }
           }
         }

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -65,7 +65,6 @@ RSpec.configure do |config|
         _name
       end
     end
-
     klass.class_exec(self, &_block) unless _block.nil?
     klass.target = target || build_type("#{_name}Target", *klass.pre_definition.fields.map(&:name))
     klass.connector.migrate if migrate


### PR DESCRIPTION
Changes:

- Query size can't be `0` anymore. It was changed to `10000`.
- Fix rollover.
- Use types `text` (instead of `string`) and `keyword` (instead of `string` with `not_analyzed`).
- Updated queries tests. I'm not sure if the changes made are correct.
- Changed time zone string format

I'm not sure if there are more changes to be made, or if the test changes are representing the expected behaviour.

All tests are passing with `elasticsearch@5.6`.