### PR TITLE
feat(query): add methods to get results using scroll api

### DIFF
--- a/lib/elastic/core/connector.rb
+++ b/lib/elastic/core/connector.rb
@@ -107,8 +107,14 @@ module Elastic::Core
       api.count(index: index_name, body: query)['count']
     end
 
-    def query(query: nil)
-      api.search(index: index_name, body: query)
+    def query(query: nil, scroll: nil)
+      query_params = { index: index_name, body: query }
+      query_params[:scroll] = scroll unless scroll.nil?
+      api.search(query_params)
+    end
+
+    def scroll_query(scroll_id: nil, scroll: nil)
+      api.scroll(body: { scroll_id: scroll_id, scroll: scroll })
     end
 
     def rollover(&_block) # rubocop:disable Metrics/MethodLength

--- a/lib/elastic/nodes/search.rb
+++ b/lib/elastic/nodes/search.rb
@@ -34,7 +34,8 @@ module Elastic::Nodes
       Elastic::Results::Root.new(
         _raw['hits'] ? prepare_hits(_raw['hits']['hits'], _formatter) : [],
         _raw['hits'] ? _raw['hits']['total'] : 0,
-        _raw['aggregations'] ? load_aggs_results(_raw['aggregations'], _formatter) : {}
+        _raw['aggregations'] ? load_aggs_results(_raw['aggregations'], _formatter) : {},
+        _raw['_scroll_id']
       )
     end
 

--- a/lib/elastic/query.rb
+++ b/lib/elastic/query.rb
@@ -70,6 +70,16 @@ module Elastic
       execute assembler.assemble_metric _node
     end
 
+    def initial_scroll(_scroll = "1m")
+      execute(assembler.assemble, _scroll)
+    end
+
+    def scroll_after(_scroll_id, _scroll = "1m")
+      query = assembler.assemble
+      raw = @index.connector.scroll_query(scroll_id: _scroll_id, scroll: _scroll)
+      query.handle_result(raw, formatter)
+    end
+
     private
 
     def with_clone(&_block)
@@ -86,8 +96,8 @@ module Elastic
       Core::QueryConfig.initial_config
     end
 
-    def execute(_query)
-      raw = @index.connector.query(query: _query.render)
+    def execute(_query, _scroll = nil)
+      raw = @index.connector.query(query: _query.render, scroll: _scroll)
       _query.handle_result(raw, formatter)
     end
 

--- a/lib/elastic/results/root.rb
+++ b/lib/elastic/results/root.rb
@@ -1,11 +1,12 @@
 module Elastic::Results
   class Root < HitCollection
-    attr_reader :aggregations, :total
+    attr_reader :aggregations, :total, :scroll_id
 
-    def initialize(_hits, _total, _aggs)
+    def initialize(_hits, _total, _aggs, _scroll_id)
       super _hits
       @total = _total
       @aggregations = Aggregations.new _aggs
+      @scroll_id = _scroll_id
     end
 
     def traverse(&_block)


### PR DESCRIPTION
### Problema

A partir de ES2 ya no se pueden realizar consultas páginadas en que `from + size > 10000`. Este límite se puede configurar a nivel de índice pero una alternativa más eficiente es el uso de la [API Scroll](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html)

### Solución propuesta

Se implementan dos métodos a `query` que se llamarían al final de una cadena para obtener los resultados.
`initial_scroll` realiza una llamada a la api `search` con el parámetro `scroll`. Esto retorna un `_scroll_id` que luego se agrega al `Result` correspondiente.
`scroll_after` recibe el último `_scroll_id` y llama a la api `scroll`, que entrega el próximo _batch_ de documentos y un nuevo `_scroll_id`