### PR TITLE
feat(build-query-from-params): extract mode from options in match

### DIFF
--- a/lib/elastic/commands/build_query_from_params.rb
+++ b/lib/elastic/commands/build_query_from_params.rb
@@ -162,6 +162,7 @@ module Elastic::Commands
       Elastic::Nodes::Match.new.tap do |node|
         node.field = _field.name
         node.query = _field.prepare_value_for_query(_options[:matches])
+        node.mode = _options[:mode]
       end
     end
   end

--- a/spec/lib/commands/build_query_from_params_spec.rb
+++ b/spec/lib/commands/build_query_from_params_spec.rb
@@ -47,7 +47,8 @@ describe Elastic::Commands::BuildQueryFromParams do
 
   it "builds the correct match node depending on field type and value" do
     expect(perform(string: 'phrase')).to be_a Elastic::Nodes::Match
-    expect(perform(string: 'phrase').query).to eq 'phrase'
+    expect(perform(string: { matches: 'phrase', mode: :phrase_prefix }).query).to eq 'phrase'
+    expect(perform(string: { matches: 'phrase', mode: :phrase_prefix }).mode).to eq :phrase_prefix
   end
 
   it "builds the correct range node depending on field type and value" do


### PR DESCRIPTION
Adds the posibility to set the mode of a match query, just like in term queries. Tested with `phrase_prefix`: 
![image](https://user-images.githubusercontent.com/12057523/61486772-3f026c00-a972-11e9-8ae9-64e210004c89.png)
