### PR TITLE
Enable use of elasticsearch 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ BikeIndex
 
 # More score manipulation:
 BikeIndex
-  .coord_similarity(false) # disable coord similarity (no score normalization)
   .boost(0.0) { must(brand: ['Trek', 'Cannondale']) } # no score
   .boost(fixed: 1.0) { should(year: 2015) } # fixed score
   .boost(fixed: 2.0) { should(year: 2016) }
@@ -150,4 +149,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/platan
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/docker-compose.services.yml
+++ b/docker-compose.services.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   elasticsearch:
-    image: elasticsearch:6.7.0
+    image: elasticsearch:7.2.0
     ports:
       - 9200
     volumes:

--- a/elastic-rails.gemspec
+++ b/elastic-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "elasticsearch", "~> 6.8"
+  spec.add_dependency "elasticsearch", "~> 7.2"
   spec.add_dependency "activesupport", [">= 4.0", "< 8.0"]
 
   spec.add_development_dependency "dotenv"

--- a/lib/elastic/configuration.rb
+++ b/lib/elastic/configuration.rb
@@ -4,7 +4,6 @@ module Elastic
       host: '127.0.0.1',
       port: 9200,
       page_size: 20,
-      coord_similarity: true,
       import_batch_size: 10_000,
       whiny_indices: false,
       api_client: nil, # set by method
@@ -14,7 +13,7 @@ module Elastic
       disable_index_name_caching: false
     }
 
-    attr_accessor :host, :port, :api_client, :index, :page_size, :coord_similarity, :logger,
+    attr_accessor :host, :port, :api_client, :index, :page_size, :logger,
       :import_batch_size, :whiny_indices, :time_zone, :disable_indexing, :disable_index_name_caching
 
     def initialize

--- a/lib/elastic/core/connector.rb
+++ b/lib/elastic/core/connector.rb
@@ -21,7 +21,7 @@ module Elastic::Core
     end
 
     def drop
-      api.indices.delete index: "#{index_name}:*"
+      api.indices.delete index: "#{index_name}_*"
       nil
     end
 
@@ -221,7 +221,7 @@ module Elastic::Core
     end
 
     def create_index_w_mapping
-      new_name = "#{index_name}:#{Time.now.to_i}"
+      new_name = "#{index_name}_#{Time.now.to_i}"
       api.indices.create index: new_name
       api.cluster.health wait_for_status: 'yellow'
       setup_index_mapping new_name

--- a/lib/elastic/core/connector.rb
+++ b/lib/elastic/core/connector.rb
@@ -1,7 +1,5 @@
 module Elastic::Core
   class Connector
-    DEFAULT_TYPE = '_doc'
-
     def initialize(_name, _mapping, settling_time: 10.seconds)
       @name = _name
       @mapping = _mapping
@@ -56,7 +54,7 @@ module Elastic::Core
 
       # TODO: validate document type
       operations = write_indices.map do |write_index|
-        { 'index' => _document.merge('_index' => write_index, '_type' => DEFAULT_TYPE) }
+        { 'index' => _document.merge('_index' => write_index) }
       end
 
       api.bulk(body: operations)
@@ -66,7 +64,7 @@ module Elastic::Core
       return if Elastic.config.disable_indexing
 
       # TODO: validate documents type
-      body = _documents.map { |doc| { 'index' => doc.merge('_type' => DEFAULT_TYPE) } }
+      body = _documents.map { |doc| { 'index' => doc } }
 
       write_indices.each do |write_index|
         retry_on_temporary_error('bulk indexing') do
@@ -83,12 +81,12 @@ module Elastic::Core
       write_index, rolling_index = write_indices
 
       operations = [{
-        'delete' => _document.merge('_index' => write_index, '_type' => DEFAULT_TYPE)
+        'delete' => _document.merge('_index' => write_index)
       }]
 
       if rolling_index
         operations << {
-          'delete' => _document.merge('_index' => rolling_index, '_type' => DEFAULT_TYPE)
+          'delete' => _document.merge('_index' => rolling_index)
         }
       end
 
@@ -243,7 +241,7 @@ module Elastic::Core
     end
 
     def mapping_synchronized?(_index)
-      type_mappings = api.indices.get_mapping(index: _index, include_type_name: false)
+      type_mappings = api.indices.get_mapping(index: _index)
       return false if type_mappings[_index].nil?
       return false if type_mappings[_index]['mappings'].empty?
 
@@ -256,7 +254,7 @@ module Elastic::Core
     end
 
     def setup_index_mapping(_index)
-      api.indices.put_mapping(index: _index, type: DEFAULT_TYPE, body: @mapping)
+      api.indices.put_mapping(index: _index, body: @mapping)
     end
 
     def transfer_alias(_alias, from: nil, to: nil)
@@ -274,7 +272,6 @@ module Elastic::Core
       {
         'create' => {
           '_id' => _hit['_id'],
-          '_type' => DEFAULT_TYPE,
           'data' => _hit['_source']
         }
       }

--- a/lib/elastic/dsl/bool_query_builder.rb
+++ b/lib/elastic/dsl/bool_query_builder.rb
@@ -1,7 +1,7 @@
 module Elastic::Dsl
   module BoolQueryBuilder
     def coord_similarity(_enable)
-      with_bool_query { |query| query.disable_coord = !_enable }
+      with_bool_query { |query| query }
     end
 
     def must(*_queries)

--- a/lib/elastic/dsl/bool_query_builder.rb
+++ b/lib/elastic/dsl/bool_query_builder.rb
@@ -1,9 +1,5 @@
 module Elastic::Dsl
   module BoolQueryBuilder
-    def coord_similarity(_enable)
-      with_bool_query { |query| query }
-    end
-
     def must(*_queries)
       with_bool_query do |query|
         node = build_query_from_params(_queries)

--- a/lib/elastic/nested_type.rb
+++ b/lib/elastic/nested_type.rb
@@ -5,7 +5,7 @@ module Elastic
     class << self
       extend Forwardable
 
-      def_delegators :query, :must, :should, :segment, :coord_similarity
+      def_delegators :query, :must, :should, :segment
     end
 
     def self.query

--- a/lib/elastic/nodes/boolean.rb
+++ b/lib/elastic/nodes/boolean.rb
@@ -10,7 +10,7 @@ module Elastic::Nodes
       new.tap { |n| n.shoulds = _nodes }
     end
 
-    attr_accessor :minimum_should_match, :disable_coord
+    attr_accessor :minimum_should_match
 
     def initialize
       super
@@ -18,7 +18,6 @@ module Elastic::Nodes
       @must_nots = []
       @shoulds = []
       @filters = []
-      @disable_coord = !Elastic.config.coord_similarity
     end
 
     def must(_node)
@@ -82,7 +81,6 @@ module Elastic::Nodes
       hash['should'] = @shoulds.map { |n| n.render(_options) } if !@shoulds.empty?
       hash['filters'] = @filters.map { |n| n.render(_options) } if !@filters.empty?
       hash['minimum_should_match'] = minimum_should_match unless minimum_should_match.nil?
-      hash['disable_coord'] = true if disable_coord
       render_boost(hash)
 
       { "bool" => hash }
@@ -123,7 +121,6 @@ module Elastic::Nodes
       _clone.shoulds = _shoulds
       _clone.filters = _filters
       _clone.minimum_should_match = @minimum_should_match
-      _clone.disable_coord = @disable_coord
       _clone
     end
   end

--- a/lib/elastic/shims/total_picking.rb
+++ b/lib/elastic/shims/total_picking.rb
@@ -5,7 +5,7 @@ module Elastic::Shims
 
       case result
       when Elastic::Results::Root
-        result.total
+        result.total['value']
       when Elastic::Results::GroupedResult
         result.map_to_group { |bucket| Elastic::Results::Metric.new(bucket.total) }
       else

--- a/lib/elastic/type.rb
+++ b/lib/elastic/type.rb
@@ -6,8 +6,8 @@ module Elastic
     class << self
       extend Forwardable
 
-      def_delegators :query, :must, :should, :segment, :stats, :maximum, :minimum, :sum, :average,
-        :coord_similarity, :limit, :offset, :pluck, :ids, :total
+      def_delegators :query, :must, :should, :segment, :stats, :maximum, :minimum, :sum,
+                     :average, :limit, :offset, :pluck, :ids, :total
     end
 
     def self.default_suffix

--- a/spec/lib/core/connector_spec.rb
+++ b/spec/lib/core/connector_spec.rb
@@ -255,9 +255,7 @@ describe Elastic::Core::Connector do
     api.indices.put_alias index: actual_index, name: index_name
     api.indices.put_alias index: actual_index, name: "#{index_name}.w"
 
-    if mapping
-      api.indices.put_mapping index: actual_index, type: '_doc', body: mapping
-    end
+    api.indices.put_mapping index: actual_index, body: mapping if mapping
 
     if records
       records.each do |r|

--- a/spec/lib/core/connector_spec.rb
+++ b/spec/lib/core/connector_spec.rb
@@ -82,7 +82,7 @@ describe Elastic::Core::Connector do
     describe "drop" do
       it "removes index" do
         expect { connector.drop }
-          .to change { api.indices.exists? index: "#{index_name}:12345" }.to false
+          .to change { api.indices.exists? index: "#{index_name}_12345" }.to false
       end
     end
 
@@ -248,7 +248,7 @@ describe Elastic::Core::Connector do
   # Some helpers
 
   def prepare_index(mapping: nil, records: nil)
-    actual_index = "#{index_name}:12345"
+    actual_index = "#{index_name}_12345"
 
     api.indices.create index: actual_index
     api.cluster.health wait_for_status: 'yellow'

--- a/spec/lib/nodes/boolean_spec.rb
+++ b/spec/lib/nodes/boolean_spec.rb
@@ -31,13 +31,6 @@ describe Elastic::Nodes::Boolean do
   let(:single_filter) { build_boolean(filter: [child_a]) }
   let(:single_must_not) { build_boolean(must_not: [child_a]) }
 
-  describe "disable_coord" do
-    it "is set to true by default if coord_similarity is disabled in configuration" do
-      expect { Elastic.configure coord_similarity: false }
-        .to change { build_boolean.disable_coord }.to true
-    end
-  end
-
   describe "render" do
     it "renders correctly" do
       expect(node.render)

--- a/spec/lib/query_spec.rb
+++ b/spec/lib/query_spec.rb
@@ -140,7 +140,6 @@ describe Elastic::Query do
     describe "each_with_score" do
       it "iterates over matching documents and its scores" do
         results = query
-                  .coord_similarity(false)
                   .boost(2.0, fixed: true) { should('tags.name' => 'baz_tag') }
                   .boost(3.0, fixed: true) { should('tags.name' => 'qux_tag') }
 


### PR DESCRIPTION
Hi 🍌 , I use the gem with Heroku and they deprecated elasticsearch 6.X from their add-on stack. This PR allows the gem to use ElasticSearch 7+. Changes that needed to be done are:

- The `disabled_cord` option has been deprecated since elasticsearch 6.x but, the parameter was ignored... now the parameter throws an exception so it had to be removed. With this change `coord_similarity` config didn't make sense so it was removed as well.
- Typed APIs has been deprecated and replaced with Typless APIs as described [here](https://www.elastic.co/blog/moving-from-types-to-typeless-apis-in-elasticsearch-7-0). So any type used on mapping and bulk ops has been removed.
- On elasticsearch 6.X `include_type_name` defaulted to `true`, now on elasticsearch 7.X it defaults to `false`
- From elasticsearch 7+ the special character `":"` is not allowed on index names. index names now uses only `"_"` for word/timestamp separation
- Finally, the search API `total` property for the hits changed it's schema from:
![Captura de Pantalla 2022-06-06 a la(s) 12 07 14](https://user-images.githubusercontent.com/46308442/172206250-895faf6c-3b69-4e82-b54e-3fb2d7a9c3ec.png)
to:
![Captura de Pantalla 2022-06-06 a la(s) 12 07 06](https://user-images.githubusercontent.com/46308442/172206278-372b32d0-4b86-4a96-be9a-dcee07af060f.png)




Note: if you want to read all the breaking changes they are [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/breaking-changes-7.0.html)

Hope this PR is well received and become useful for someone else!

This PR also resolves #10 