### PR TITLE
feat: improves ruby 3 compatibility

### DIFF
--- a/lib/elastic/commands/build_sort_from_params.rb
+++ b/lib/elastic/commands/build_sort_from_params.rb
@@ -29,7 +29,7 @@ module Elastic::Commands
       path = parse_nesting_path(_field)
       raise NotImplementedError, "nested fields not yet supported in sorting" if path
 
-      node.add_sort(_field, _options)
+      node.add_sort(_field, **_options)
     end
 
     def parse_nesting_path(_field)

--- a/lib/elastic/dsl/metric_builder.rb
+++ b/lib/elastic/dsl/metric_builder.rb
@@ -43,7 +43,7 @@ module Elastic::Dsl
     def aggregate_metric(_klass, _field, _options, _default_name, &_block)
       # TODO: detect nested name and wrap node
       name = _options.delete(:as) || sprintf(_default_name, _field)
-      node = _klass.build(name, _field, _options)
+      node = _klass.build(name, _field, **_options)
       _block.call node unless _block.nil?
       aggregate node
     end

--- a/lib/elastic/version.rb
+++ b/lib/elastic/version.rb
@@ -1,3 +1,3 @@
 module Elastic
-  VERSION = "1.0.3"
+  VERSION = "1.0.4"
 end


### PR DESCRIPTION
Ruby 3 introduces some expected breaking changes on how keywords arguments are passed to methods (more info [here](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)). This pull request ensures the gem's compatibility with both Ruby 2 and 3 versions